### PR TITLE
Update bayesian_segnet_kitti.prototxt

### DIFF
--- a/config/bayesian_segnet/standard/kitti/bayesian_segnet_kitti.prototxt
+++ b/config/bayesian_segnet/standard/kitti/bayesian_segnet_kitti.prototxt
@@ -845,8 +845,6 @@ layer {
   bottom: "pool5_mask"
   upsample_param {
     scale: 2
-    upsample_w: 30
-    upsample_h: 23
   }
 }
 layer {
@@ -1039,8 +1037,6 @@ layer {
   bottom: "pool4_mask"
   upsample_param {
     scale: 2
-    upsample_w: 60
-    upsample_h: 45
   }
 }
 layer {


### PR DESCRIPTION
Remove `upsample_h` and `upsample_w` from the configuration file in Bayesian SegNet standard.